### PR TITLE
Add provider regex pack (Azure, Discord, Firebase, Cloudflare, Postgres

### DIFF
--- a/src/detectors.js
+++ b/src/detectors.js
@@ -1,14 +1,28 @@
 // SnipGuard detectors: API keys, PII, simple code heuristics (on-device only)
 const SG_RE = {
   // Secrets
-  openai: /sk-[A-Za-z0-9]{20,}/g,                 // OpenAI
-  gh_pat: /github_pat_[A-Za-z0-9_]{80,}/g,        // GitHub PAT
-  slack: /xo(?:xa|xb|xp)-[A-Za-z0-9-]{10,48}/g,   // Slack tokens
-  stripe: /sk_(?:test|live)_[A-Za-z0-9]{20,}/g,   // Stripe secret key
-  aws_akid: /AKIA[0-9A-Z]{16}/g,                  // AWS access key id
-  gcp_api: /\bAIza[0-9A-Za-z\-_]{35}\b/g,      // Google API key
-  twilio: /SK[0-9a-fA-F]{32}/g,                   // Twilio API key (one pattern)
-  telegram_bot: /(?:(?:^|[^a-zA-Z]))\d{9,10}:[A-Za-z0-9_-]{35}/g, // Telegram bot token
+  openai: /sk-[A-Za-z0-9]{20,}/g,                                               // OpenAI
+  gh_pat: /github_pat_[A-Za-z0-9_]{80,}/g,                                      // GitHub PAT
+  slack: /xo(?:xa|xb|xp)-[A-Za-z0-9-]{10,48}/g,                                 // Slack tokens
+  stripe: /sk_(?:test|live)_[A-Za-z0-9]{20,}/g,                                 // Stripe secret key
+  aws_akid: /AKIA[0-9A-Z]{16}/g,                                                // AWS access key id
+  gcp_api: /\bAIza[0-9A-Za-z\-_]{35}\b/g,                                       // Google API key
+  twilio: /SK[0-9a-fA-F]{32}/g,                                                 // Twilio API key (one pattern)
+  telegram_bot: /(?:(?:^|[^a-zA-Z]))\d{9,10}:[A-Za-z0-9_-]{35}/g,               // Telegram bot token
+  // Azure Storage connection string, doc: https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string
+  azure_storage_conn: /DefaultEndpointsProtocol=(?:https|http);AccountName=[a-z0-9]{3,24};AccountKey=[A-Za-z0-9+/=]{40,}=;EndpointSuffix=core\.windows\.net/gi,
+  // Azure SQL connection string, doc: https://learn.microsoft.com/en-us/azure/azure-sql/database/connect-query-content-reference-guide
+  azure_sql_conn: /Server=tcp:[A-Za-z0-9\-.]+,?\d*;Database=[A-Za-z0-9_\-]+;User ID=[^;]+;Password=[^;]+;/i,
+  // Azure AD application client secret, doc: https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials
+  azure_client_secret: /AZURE_CLIENT_SECRET\s*[:=]\s*[A-Za-z0-9._~+\-/]{16,}/g,
+  // Discord bot token, doc: https://discord.com/developers/docs/reference
+  discord_bot: /[0-9]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27}/g,
+  // Firebase OAUTH bearer token doc: https://firebase.google.com/docs/cloud-messaging/send/v1-api
+  google_oauth_access_token: /\bya29\.[A-Za-z0-9_-]{20,}\b/g,
+  // Cloudflare API Token, doc: https://developers.cloudflare.com/fundamentals/api/get-started/create-token/
+  cloudflare_api_token: /(CF_API_TOKEN|CLOUDFLARE_API_TOKEN)\s*[:=]\s*[A-Za-z0-9-_]{40,}/i,
+  // PostgreSQL connection URI, doc: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+  postgres_url_creds: /\bpostgres(?:ql)?:\/\/[^:\s\/]+:[^@\s\/]+@[^\/\s:]+(?::\d+)?\/[A-Za-z0-9._\-]+(?:\?[^\s'"]+)?\b/,
   // PEM blocks
   pem: /-----BEGIN (?:RSA|EC|OPENSSH|PRIVATE) KEY-----[\s\S]+?-----END [^-]+-----/g,
   // PII

--- a/tests/detectors.spec.mjs
+++ b/tests/detectors.spec.mjs
@@ -48,3 +48,56 @@ describe('Sanitization', () => {
     expect(s.includes('[[REDACTED_OPENAI]]') || s.includes('[[REDACTED_HIGH_ENTROPY]]')).toBeTruthy();
   });
 });
+
+// New Provider Regex Pack Tests (Azure, Discord, Firebase, Cloudflare, Postgres)
+
+describe('Provider regex pack (doc-backed)', () => {
+  it('detects Discord bot tokens', () => {
+    const t = 'discord token 123456789012345678901234.AbCdEf.ghIjKlMnOpQrStUvWxYz123';
+    const r = sgDetectAll(t);
+    expect(r.api.length > 0).toBeTruthy();
+  });
+
+  it('detects Firebase OAuth access tokens (ya29 prefix)', () => {
+    const t = 'Authorization: Bearer ya29.A0AVA9yAbCdEfGhIjKlMnOpQrStUvWxYz_123456';
+    const r = sgDetectAll(t);
+    expect(r.api.length > 0).toBeTruthy();
+  });
+
+  it('detects Azure client secret', () => {
+    const t = 'AZURE_CLIENT_SECRET=AbCdEfGhIjKlMnOp_QrSt+UvWx~';
+    const r = sgDetectAll(t);
+    expect(r.api.length > 0).toBeTruthy();
+  });
+
+  it('detects Azure Storage connection strings', () => {
+    const t = 'DefaultEndpointsProtocol=https;AccountName=storacctdemo;AccountKey=QWErTYuIOpASDFGhJKLzxcvbNm1234567890abcd=;EndpointSuffix=core.windows.net';
+    const r = sgDetectAll(t);
+    expect(r.api.length > 0).toBeTruthy();
+  });
+
+  it('detects Azure SAS tokens', () => {
+    const t = 'https://mystorage.blob.core.windows.net/container/file.txt?sv=2023-11-03&ss=bfqt&srt=sco&sp=rwdlacupiytfx&se=2030-01-01T00:00:00Z&st=2025-01-01T00:00:00Z&spr=https&sig=AbCdEfGhIjKlMnOpQrSt';
+    const r = sgDetectAll(t);
+    expect(r.api.length > 0).toBeTruthy();
+  });
+
+  it('detects Azure SQL connection strings', () => {
+    const t = 'Server=tcp:myserver.database.windows.net,1433;Database=appdb;User ID=appuser@tenant;Password=Sup3r$ecret!;Encrypt=true;';
+    const r = sgDetectAll(t);
+    expect(r.api.length > 0).toBeTruthy();
+  });
+
+  it('detects Cloudflare API tokens', () => {
+    const t = 'CLOUDFLARE_API_TOKEN=AbCdEfGhIjKlMnOpQrStUvWxYz0123456789abcd';
+    const r = sgDetectAll(t);
+    expect(r.api.length > 0).toBeTruthy();
+  });
+
+  it('detects PostgreSQL URLs with embedded credentials', () => {
+    const t = 'postgres://appuser:Sup3r%24ecret@db.internal.local:5432/appdb?sslmode=require';
+    const r = sgDetectAll(t);
+    expect(r.api.length > 0).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
Added regex patterns and comments for:

Azure: client secrets, storage connection strings, SQL connection strings.
Discord: bot tokens.
Firebase: OAuth access tokens.
Cloudflare: modern scoped API tokens.
Postgres: connection URIs with embedded credentials.

Docs included
All patterns include references to official documentation URLs.

Testing
Added synthetic examples to verify match accuracy for each provider.

Fixes #9